### PR TITLE
fixed title.

### DIFF
--- a/rfc7009.ja.xml
+++ b/rfc7009.ja.xml
@@ -44,7 +44,10 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
+<!--
 <rfc category="std" docName="draft-ietf-oauth-revocation-11" ipr="trust200902">
+-->
+<rfc submissionType="IETF" category="std" consensus="yes" ipr="trust200902" number="7009">
   <!--gran
 		category values: std, bcp, info, exp, and historic ipr values:
 		full3667, noModification3667, noDerivatives3667 you can add the


### PR DESCRIPTION
draft-ietf-oauth-revocation-11をタイトルから削除
- https://github.com/openid-foundation-japan/oauth-revocation/issues/3
